### PR TITLE
add original modelPropertyNaming to command

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ const latestReleaseUri = `${repo}/releases/latest`
 shell.mkdir(tmpFolder);
 
 const generateTemplate = (f, p = argv.packageName, o = argv.output) => {
-    const generateCommand = `node ./openapi-generator-cli/bin/openapi-generator generate --skip-validate-spec -i "${f}" ${argv.templatesPath ? `-t ${argv.templatesPath}` : ""} ${p ? `--package-name ${p}` : ""} -g ${argv.language} -o ${o}`
+    const generateCommand = `node ./openapi-generator-cli/bin/openapi-generator generate --skip-validate-spec -i "${f}" ${argv.templatesPath ? `-t ${argv.templatesPath}` : ""} ${p ? `--package-name ${p}` : ""} -g ${argv.language} -o ${o} --additional-properties modelPropertyNaming=original`
     const command = argv.modelsOnly ? `export JAVA_OPTS='-Dmodels -DskipFormModel=true' && ${generateCommand}` : generateCommand
     shell.exec(command, { silent: true });
 }


### PR DESCRIPTION
## Summary
Right now the openapi-generator does not respect API field names started with an upper case character.
This causes issues for various types throughout the API.
Adding this flag fixes this issue.

